### PR TITLE
fix configfromfile test to use new Getopt::Long::Descriptive text

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -12,6 +12,7 @@ author = Florian Ragwitz <rafl@debian.org>
 author = Dagfinn Ilmari Mannsaker <ilmari@ilmari.org>
 author = Avar Arnfjord Bjarmason <avar@cpan.org>
 author = Chris Prather <perigrin@cpan.org>
+author = Mark Gardner <mjgardner@cpan.org>
 license = Perl_5
 copyright_holder = Infinity Interactive, Inc
 
@@ -24,7 +25,7 @@ auto_prereq = 0
 
 [Prereq]
 Getopt::Long = 2.37
-Getopt::Long::Descriptive = 0.081
+Getopt::Long::Descriptive = 0.091
 Mouse = 0.64
 
 [Prereq / TestRequires]

--- a/t/008_configfromfile.t
+++ b/t/008_configfromfile.t
@@ -91,7 +91,7 @@ else
 {
     local @ARGV = qw( --required_from_argv 1 );
 
-    throws_ok { App->new_with_options } qr/Required option missing: required_from_config/;
+    throws_ok { App->new_with_options } qr/Mandatory parameter 'required_from_config' missing/;
 
     {
         my $app = App::DefaultConfigFile->new_with_options;
@@ -160,7 +160,7 @@ else
 # Required arg not supplied from cmdline
 {
     local @ARGV = qw( --configfile /notused );
-    throws_ok { App->new_with_options } qr/Required option missing: required_from_argv/;
+    throws_ok { App->new_with_options } qr/Mandatory parameter 'required_from_argv' missing/;
 }
 
 # Config file value overriden from cmdline


### PR DESCRIPTION
Getopt::Long::Descriptive changed its error messages in v0.091 and broke one of your tests. This should fix it and require that version of GLD.
