### PR TITLE
Cope with GLD output changes in version 0.099

### DIFF
--- a/t/104_override_usage.t
+++ b/t/104_override_usage.t
@@ -43,10 +43,17 @@ use Test::Exception;
     my $exp = [
          'Unknown option: q
 ',
+         $Getopt::Long::Descriptive::VERSION < 0.099 ?
          qq{usage: 104_override_usage.t [-?] [long options...]
 \t-? --usage --help  Prints this usage information.
 \t--foo              A foo
 }
+        :
+         qq{usage: 104_override_usage.t [-?] [long options...]
+\t-? --usage --help    Prints this usage information.
+\t--foo INT            A foo
+}
+
      ];
 
      is_deeply \@MyScript::exception, $exp;

--- a/t/107_no_auto_help.t
+++ b/t/107_no_auto_help.t
@@ -60,7 +60,7 @@ END {
 warning_like {
     throws_ok { Class->new_with_options }
            #usage: 107_no_auto_help.t [-?] [long options...]
-        qr/^usage: [\d\w]+\Q.t [-?] [long options...]\E.\s+\Q-? --usage --help  Prints this usage information.\E.\s+--configfile/ms,
+        qr/^usage: [\d\w]+\Q.t [-?] [long options...]\E.\s+\Q-? --usage --help\E\s+\QPrints this usage information.\E.\s+--configfile/ms,
         'usage information looks good';
     }
     qr/^Specified configfile \'this_value_unimportant\' does not exist, is empty, or is not readable$/,

--- a/t/109_help_flag.t
+++ b/t/109_help_flag.t
@@ -40,7 +40,7 @@ foreach my $args ( ['--help'], ['--usage'], ['--?'], ['-?'] )
     local @ARGV = @$args;
 
     throws_ok { MyClass->new_with_options() }
-        qr/^usage: (?:[\d\w]+)\Q.t [-?] [long options...]\E.^\t\Q-? --usage --help  Prints this usage information.\E$/ms,
+        qr/^usage: (?:[\d\w]+)\Q.t [-?] [long options...]\E.^\t\Q-? --usage --help\E\s+\QPrints this usage information.\E$/ms,
         'Help request detected; usage information properly printed';
 }
 

--- a/t/110_sort_usage_by_attr_order.t
+++ b/t/110_sort_usage_by_attr_order.t
@@ -34,6 +34,16 @@ usage: 110_sort_usage_by_attr_order.t [-?] [long options...]
     --bar              Documentation for "bar"
     --baz              Documentation for "baz"
 USAGE
+if ( $Getopt::Long::Descriptive::VERSION >= 0.099 )
+{
+$expected = <<'USAGE';
+usage: 110_sort_usage_by_attr_order.t [-?] [long options...]
+    -? --usage --help    Prints this usage information.
+    --foo STR            Documentation for "foo"
+    --bar STR            Documentation for "bar"
+    --baz STR            Documentation for "baz"
+USAGE
+}
 $expected =~ s/^[ ]{4}/\t/xmsg;
 is($obj->usage->text, $expected, 'Usage text has nicely sorted options');
 


### PR DESCRIPTION
The output text format of Getopt::Long::Descriptive changed again at version 0.099 and broke some of the tests. This change fixes the tests without breaking compatibility with older versions of Getopt::Long::Descriptive.