### PR TITLE
Cope with GLD output changes in version 0.100

### DIFF
--- a/t/104_override_usage.t
+++ b/t/104_override_usage.t
@@ -49,9 +49,15 @@ use Test::Exception;
 \t--foo              A foo
 }
         :
+         $Getopt::Long::Descriptive::VERSION == 0.099 ?
          qq{usage: 104_override_usage.t [-?] [long options...]
 \t-? --usage --help    Prints this usage information.
 \t--foo INT            A foo
+}
+        :
+         qq{usage: 104_override_usage.t [-?] [long options...]
+\t-? --usage --help  Prints this usage information.
+\t--foo INT          A foo
 }
 
      ];

--- a/t/110_sort_usage_by_attr_order.t
+++ b/t/110_sort_usage_by_attr_order.t
@@ -34,7 +34,7 @@ usage: 110_sort_usage_by_attr_order.t [-?] [long options...]
     --bar              Documentation for "bar"
     --baz              Documentation for "baz"
 USAGE
-if ( $Getopt::Long::Descriptive::VERSION >= 0.099 )
+if ( $Getopt::Long::Descriptive::VERSION == 0.099 )
 {
 $expected = <<'USAGE';
 usage: 110_sort_usage_by_attr_order.t [-?] [long options...]
@@ -42,6 +42,16 @@ usage: 110_sort_usage_by_attr_order.t [-?] [long options...]
     --foo STR            Documentation for "foo"
     --bar STR            Documentation for "bar"
     --baz STR            Documentation for "baz"
+USAGE
+}
+if ( $Getopt::Long::Descriptive::VERSION >= 0.100 )
+{
+$expected = <<'USAGE';
+usage: 110_sort_usage_by_attr_order.t [-?] [long options...]
+    -? --usage --help  Prints this usage information.
+    --foo STR          Documentation for "foo"
+    --bar STR          Documentation for "bar"
+    --baz STR          Documentation for "baz"
 USAGE
 }
 $expected =~ s/^[ ]{4}/\t/xmsg;


### PR DESCRIPTION
The output text format of Getopt::Long::Descriptive changed yet again at version 0.099 and broke some of the tests. This change fixes the tests without breaking compatibility with older versions of Getopt::Long::Descriptive.