### PR TITLE
do not declare help_flag as a 'Bool'

### DIFF
--- a/lib/MouseX/Getopt/GLD.pm
+++ b/lib/MouseX/Getopt/GLD.pm
@@ -14,7 +14,7 @@ has usage => (
 
 # captures the options: --help --usage --?
 has help_flag => (
-    is => 'ro', isa => 'Bool',
+    is => 'ro',
     traits => ['Getopt'],
     cmd_flag => 'help',
     cmd_aliases => [ qw(usage ?) ],


### PR DESCRIPTION

In Debian we are currently applying the following patch to
MouseX-Getopt.
We thought you might be interested in it too.

    Description: do not declare help_flag as a 'Bool'
     This causes problems with Getopt::Long::Descriptive 0.103, which adds '[no-]'
     to boolean options breaking the test suite. '--[no-]help' is not really
     wanted.
     See for example https://ci.debian.net/data/autopkgtest/testing/amd64/libm/libmousex-getopt-perl/760884/log.gz
    Author: Damyan Ivanov <dmn@debian.org>
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libmousex-getopt-perl/raw/master/debian/patches/no-bool-for-help-usage.patch

Thanks for considering,
  Damyan Ivanov,
  Debian Perl Group
