### PR TITLE
Cope with GLD output changes in version 0.103

### DIFF
--- a/t/104_override_usage.t
+++ b/t/104_override_usage.t
@@ -55,9 +55,15 @@ use Test::Exception;
 \t--foo INT            A foo
 }
         :
+         $Getopt::Long::Descriptive::VERSION < 0.103 ?
          qq{usage: 104_override_usage.t [-?] [long options...]
 \t-? --usage --help  Prints this usage information.
 \t--foo INT          A foo
+}
+        :
+         qq{usage: 104_override_usage.t [-?] [long options...]
+\t-? --[no-]usage --[no-]help       Prints this usage information.
+\t--foo INT                         A foo
 }
 
      ];

--- a/t/107_no_auto_help.t
+++ b/t/107_no_auto_help.t
@@ -60,7 +60,7 @@ END {
 warning_like {
     throws_ok { Class->new_with_options }
            #usage: 107_no_auto_help.t [-?] [long options...]
-        qr/^usage: [\d\w]+\Q.t [-?] [long options...]\E.\s+\Q-? --usage --help\E\s+\QPrints this usage information.\E.\s+--configfile/ms,
+        qr/^usage: [\d\w]+\Q.t [-?] [long options...]\E.\s+\Q-? --\E(\[no-\])?usage --(\[no-\])?\Qhelp\E\s+\QPrints this usage information.\E.\s+--configfile/ms,
         'usage information looks good';
     }
     qr/^Specified configfile \'this_value_unimportant\' does not exist, is empty, or is not readable$/,

--- a/t/109_help_flag.t
+++ b/t/109_help_flag.t
@@ -40,7 +40,7 @@ foreach my $args ( ['--help'], ['--usage'], ['--?'], ['-?'] )
     local @ARGV = @$args;
 
     throws_ok { MyClass->new_with_options() }
-        qr/^usage: (?:[\d\w]+)\Q.t [-?] [long options...]\E.^\t\Q-? --usage --help\E\s+\QPrints this usage information.\E$/ms,
+        qr/^usage: (?:[\d\w]+)\Q.t [-?] [long options...]\E.^\t\Q-? --\E(\[no-\])?usage --(\[no-\])?help\s+\QPrints this usage information.\E$/ms,
         'Help request detected; usage information properly printed';
 }
 

--- a/t/110_sort_usage_by_attr_order.t
+++ b/t/110_sort_usage_by_attr_order.t
@@ -54,6 +54,16 @@ usage: 110_sort_usage_by_attr_order.t [-?] [long options...]
     --baz STR          Documentation for "baz"
 USAGE
 }
+if ( $Getopt::Long::Descriptive::VERSION >= 0.103 )
+{
+$expected = <<'USAGE';
+usage: 110_sort_usage_by_attr_order.t [-?] [long options...]
+    -? --[no-]usage --[no-]help       Prints this usage information.
+    --foo STR                         Documentation for "foo"
+    --bar STR                         Documentation for "bar"
+    --baz STR                         Documentation for "baz"
+USAGE
+}
 $expected =~ s/^[ ]{4}/\t/xmsg;
 is($obj->usage->text, $expected, 'Usage text has nicely sorted options');
 


### PR DESCRIPTION
The output text format of Getopt::Long::Descriptive changed yet again at version 0.103 and broke some of the tests (#12). This change fixes the tests without breaking compatibility with older versions of Getopt::Long::Descriptive.

This is an alternative fix to #11 if you prefer to leave help/usage as a boolean option.
