### PR TITLE
Another gld output fix

### DIFF
--- a/t/104_override_usage.t
+++ b/t/104_override_usage.t
@@ -61,15 +61,15 @@ use Test::Exception;
 \t--foo INT          A foo
 }
         :
-         $Getopt::Long::Descriptive::VERSION < 0.106 ?
+         # Note: Getopt::Long::Descriptive 0.106 not supported
+         $Getopt::Long::Descriptive::VERSION < 0.107 ?
          qq{usage: 104_override_usage.t [-?] [long options...]
 \t-? --[no-]usage --[no-]help       Prints this usage information.
 \t--foo INT                         A foo
 }
         :
          qq{usage: 104_override_usage.t [-?] [long options...]
-\t--[no-]help (or -?)  Prints
-\t             this usage information.
+\t--[no-]help (or -?)  Prints this usage information.
 \t             aka --usage
 \t--foo INT    A foo
 }

--- a/t/104_override_usage.t
+++ b/t/104_override_usage.t
@@ -61,9 +61,17 @@ use Test::Exception;
 \t--foo INT          A foo
 }
         :
+         $Getopt::Long::Descriptive::VERSION < 0.106 ?
          qq{usage: 104_override_usage.t [-?] [long options...]
 \t-? --[no-]usage --[no-]help       Prints this usage information.
 \t--foo INT                         A foo
+}
+        :
+         qq{usage: 104_override_usage.t [-?] [long options...]
+\t--[no-]help (or -?)  Prints
+\t             this usage information.
+\t             aka --usage
+\t--foo INT    A foo
 }
 
      ];

--- a/t/104_override_usage.t
+++ b/t/104_override_usage.t
@@ -68,10 +68,17 @@ use Test::Exception;
 \t--foo INT                         A foo
 }
         :
+         $Getopt::Long::Descriptive::VERSION < 0.113 ?
          qq{usage: 104_override_usage.t [-?] [long options...]
 \t--[no-]help (or -?)  Prints this usage information.
 \t             aka --usage
 \t--foo INT    A foo
+}
+        :
+         qq{usage: 104_override_usage.t [-?] [long options...]
+    --[no-]help (or -?)  Prints this usage information.
+                 aka --usage
+    --foo INT    A foo
 }
 
      ];

--- a/t/107_no_auto_help.t
+++ b/t/107_no_auto_help.t
@@ -60,7 +60,7 @@ END {
 warning_like {
     throws_ok { Class->new_with_options }
            #usage: 107_no_auto_help.t [-?] [long options...]
-        qr/^usage: [\d\w]+\Q.t [-?] [long options...]\E.\s+\Q-? --\E(\[no-\])?usage --(\[no-\])?\Qhelp\E\s+\QPrints this usage information.\E.\s+--configfile/ms,
+        qr/^usage: [\d\w]+\Q.t [-?] [long options...]\E.\s+(\Q-? --\E(\[no-\])?usage )?--(\[no-\])?\Qhelp\E(\Q (or -?)\E)?\s+\QPrints this usage information.\E.(\s+\Qaka --usage\E.)?\s+--configfile/ms,
         'usage information looks good';
     }
     qr/^Specified configfile \'this_value_unimportant\' does not exist, is empty, or is not readable$/,

--- a/t/109_help_flag.t
+++ b/t/109_help_flag.t
@@ -40,7 +40,7 @@ foreach my $args ( ['--help'], ['--usage'], ['--?'], ['-?'] )
     local @ARGV = @$args;
 
     throws_ok { MyClass->new_with_options() }
-        qr/^usage: (?:[\d\w]+)\Q.t [-?] [long options...]\E.^\t\Q-? --\E(\[no-\])?usage --(\[no-\])?help\s+\QPrints this usage information.\E$/ms,
+        qr/^usage: (?:[\d\w]+)\Q.t [-?] [long options...]\E.^\s+(\Q-? --\E(\[no-\])?usage )?--(\[no-\])?help(\Q (or -?)\E)?\s+Prints ?(.\s+)?\Qthis usage information.\E.(\s+\Qaka --usage\E.)?$/ms,
         'Help request detected; usage information properly printed';
 }
 

--- a/t/110_sort_usage_by_attr_order.t
+++ b/t/110_sort_usage_by_attr_order.t
@@ -64,12 +64,12 @@ usage: 110_sort_usage_by_attr_order.t [-?] [long options...]
     --baz STR                         Documentation for "baz"
 USAGE
 }
-if ( $Getopt::Long::Descriptive::VERSION >= 0.106 )
+# Note: Getopt::Long::Descriptive 0.106 not supported
+if ( $Getopt::Long::Descriptive::VERSION >= 0.107 )
 {
 $expected = <<'USAGE';
 usage: 110_sort_usage_by_attr_order.t [-?] [long options...]
-    --[no-]help (or -?)  Prints
-                 this usage information.
+    --[no-]help (or -?)  Prints this usage information.
                  aka --usage
     --foo STR    Documentation for "foo"
     --bar STR    Documentation for "bar"

--- a/t/110_sort_usage_by_attr_order.t
+++ b/t/110_sort_usage_by_attr_order.t
@@ -76,6 +76,6 @@ usage: 110_sort_usage_by_attr_order.t [-?] [long options...]
     --baz STR    Documentation for "baz"
 USAGE
 }
-$expected =~ s/^[ ]{4}/\t/xmsg;
+$expected =~ s/^[ ]{4}/\t/xmsg unless $Getopt::Long::Descriptive::VERSION >= 0.113;
 is($obj->usage->text, $expected, 'Usage text has nicely sorted options');
 

--- a/t/110_sort_usage_by_attr_order.t
+++ b/t/110_sort_usage_by_attr_order.t
@@ -64,6 +64,18 @@ usage: 110_sort_usage_by_attr_order.t [-?] [long options...]
     --baz STR                         Documentation for "baz"
 USAGE
 }
+if ( $Getopt::Long::Descriptive::VERSION >= 0.106 )
+{
+$expected = <<'USAGE';
+usage: 110_sort_usage_by_attr_order.t [-?] [long options...]
+    --[no-]help (or -?)  Prints
+                 this usage information.
+                 aka --usage
+    --foo STR    Documentation for "foo"
+    --bar STR    Documentation for "bar"
+    --baz STR    Documentation for "baz"
+USAGE
+}
 $expected =~ s/^[ ]{4}/\t/xmsg;
 is($obj->usage->text, $expected, 'Usage text has nicely sorted options');
 


### PR DESCRIPTION
The output text format of Getopt::Long::Descriptive changed yet again at version 0.107 and broke some of the tests (#14). This change fixes the tests without breaking compatibility with older versions of Getopt::Long::Descriptive.

Note that Getopt::Long::Descriptive 0.106 was an experiment with using Term::ReadKey to get the terminal width so that output could be formatted accordingly. That change was reverted in Getopt::Long::Descriptive 0.107 and this PR explicitly does not support use with Getopt::Long::Descriptive 0.106.